### PR TITLE
This change makes all input forms compatable with iron-form

### DIFF
--- a/xp-input-behavior.html
+++ b/xp-input-behavior.html
@@ -714,6 +714,8 @@ This behavior is used to add input capabilities on a custom element.
 
             // Focusing
             if (self.autoFocus) { XP.delay(function () { self.focus(); }); }
+            
+            self.fire('iron-form-element-register');
         },
 
         // LISTENER


### PR DESCRIPTION
I'm not sure what are the design considerations here, but I was mixing polymer paper elements and mat-editor element and I couldn't easily serialize the content of my form into JSON object. 

**paper-input** on attach fires this event: **iron-form-element-register** which registers the form elements with **iron-form** for later serialization.

Here is the issue that It tries to solve: https://github.com/expandjs/mat-editor/issues/1

If this is not a design consideration fell free to reject this PR.
